### PR TITLE
classes: migrate manifest before parsing in /thingpedia/classes

### DIFF
--- a/model/device.js
+++ b/model/device.js
@@ -71,17 +71,17 @@ module.exports = {
 
     getFullCodeByPrimaryKind(client, kind, orgId) {
         if (orgId === -1) {
-            return db.selectAll(client, "select code, version, approved_version, developer_version from device_code_version dcv, device_class d "
+            return db.selectAll(client, "select code, version, approved_version, developer_version, primary_kind, category from device_code_version dcv, device_class d "
                                 + "where d.primary_kind = ? and dcv.device_id = d.id "
                                 + "and dcv.version = d.developer_version", [kind]);
         } else if (orgId !== null) {
-            return db.selectAll(client, "select code, version, approved_version, developer_version from device_code_version dcv, device_class d "
+            return db.selectAll(client, "select code, version, approved_version, developer_version, primary_kind, category from device_code_version dcv, device_class d "
                                 + "where d.primary_kind = ? and dcv.device_id = d.id "
                                 + "and ((dcv.version = d.developer_version and d.owner = ?) "
                                 + "or (dcv.version = d.approved_version and d.owner <> ?))",
                                 [kind, orgId, orgId]);
         } else {
-            return db.selectAll(client, "select code, version, approved_version, developer_version from device_code_version dcv, device_class d "
+            return db.selectAll(client, "select code, version, approved_version, developer_version, primary_kind, category from device_code_version dcv, device_class d "
                                 + "where d.primary_kind = ? and dcv.device_id = d.id "
                                 + "and dcv.version = d.approved_version", [kind]);
         }

--- a/routes/thingpedia_schemas.js
+++ b/routes/thingpedia_schemas.js
@@ -21,6 +21,7 @@ const exampleModel = require('../model/example');
 
 const SchemaUtils = require('../util/manifest_to_schema');
 const DatasetUtils = require('../util/dataset');
+const Importer = require('../util/import_device');
 const I18n = require('../util/i18n');
 
 var router = express.Router();
@@ -47,7 +48,7 @@ router.get('/by-id/:kind', (req, res, next) => {
                                               message: req._("Not Found.") });
             return;
         }
-        const classDef = ThingTalk.Grammar.parse(devices[0].code);
+        const classDef = ThingTalk.Grammar.parse(Importer.migrateManifest(devices[0].code, devices[0]));
         const schema = schemas[0];
         SchemaUtils.mergeClassDefAndSchema(classDef, schema);
 


### PR DESCRIPTION
Otherwise, opening the class page of an unmigrated device crashes
the server.

Fixes #82