### PR TITLE
Fix migration of device factories

### DIFF
--- a/model/device.js
+++ b/model/device.js
@@ -373,18 +373,18 @@ module.exports = {
     getDevicesForSetup(client, names, org) {
         if (org !== null && org.is_admin) {
             const query = `
-                (select d.primary_kind, d.primary_kind as for_kind, dcv.code, dcv.factory
+                (select d.primary_kind, d.name, d.category, d.primary_kind as for_kind, dcv.code, dcv.factory
                  from device_class d, device_code_version dcv where d.id = dcv.device_id and
                  dcv.version = d.developer_version
                  and d.primary_kind in (?))
                 union all
-                (select d.primary_kind, dck.kind as for_kind, dcv.code, dcv.factory from device_class d,
+                (select d.primary_kind, d.name, d.category, dck.kind as for_kind, dcv.code, dcv.factory from device_class d,
                  device_code_version dcv, device_class_kind dck where dck.device_id = d.id and
                  d.id = dcv.device_id and
                  dcv.version = d.developer_version
                  and dck.kind in (?))
                 union all
-                (select d.primary_kind, dck2.kind as for_kind, dcv.code, dcv.factory from device_class d,
+                (select d.primary_kind, d.name, d.category, dck2.kind as for_kind, dcv.code, dcv.factory from device_class d,
                  device_class d2, device_class_kind dck2, device_code_version dcv, device_class_kind dck
                  where dck.device_id = d.id and d.id = dcv.device_id and
                  dcv.version = d.developer_version
@@ -392,20 +392,20 @@ module.exports = {
             return db.selectAll(client, query, [names, names, names]);
         } else if (org !== null) {
             const query = `
-                (select d.primary_kind, d.primary_kind as for_kind, dcv.code, dcv.factory
+                (select d.primary_kind, d.name, d.category, d.primary_kind as for_kind, dcv.code, dcv.factory
                  from device_class d, device_code_version dcv where d.id = dcv.device_id and
                  ((dcv.version = d.developer_version and d.owner = ?) or
                   (dcv.version = d.approved_version and d.owner <> ?))
                  and d.primary_kind in (?))
                 union all
-                (select d.primary_kind, dck.kind as for_kind, dcv.code, dcv.factory from device_class d,
+                (select d.primary_kind, d.name, d.category, dck.kind as for_kind, dcv.code, dcv.factory from device_class d,
                  device_code_version dcv, device_class_kind dck where dck.device_id = d.id and
                  d.id = dcv.device_id and
                  ((dcv.version = d.developer_version and d.owner = ?) or
                   (dcv.version = d.approved_version and d.owner <> ?))
                  and dck.kind in (?))
                 union all
-                (select d.primary_kind, dck2.kind as for_kind, dcv.code, dcv.factory from device_class d,
+                (select d.primary_kind, d.name, d.category, dck2.kind as for_kind, dcv.code, dcv.factory from device_class d,
                  device_class d2, device_class_kind dck2, device_code_version dcv, device_class_kind dck
                  where dck.device_id = d.id and d.id = dcv.device_id and
                  ((dcv.version = d.developer_version and d.owner = ?) or
@@ -414,18 +414,18 @@ module.exports = {
             return db.selectAll(client, query, [org.id, org.id, names, org.id, org.id, names, org.id, org.id, names]);
         } else {
             const query = `
-                (select d.primary_kind, d.primary_kind as for_kind, dcv.code, dcv.factory
+                (select d.primary_kind, d.name, d.category, d.primary_kind as for_kind, dcv.code, dcv.factory
                  from device_class d, device_code_version dcv where d.id = dcv.device_id and
                  dcv.version = d.approved_version
                  and d.primary_kind in (?))
                 union all
-                (select d.primary_kind, dck.kind as for_kind, dcv.code, dcv.factory from device_class d,
+                (select d.primary_kind, d.name, d.category, dck.kind as for_kind, dcv.code, dcv.factory from device_class d,
                  device_code_version dcv, device_class_kind dck where dck.device_id = d.id and
                  d.id = dcv.device_id and
                  dcv.version = d.approved_version
                  and dck.kind in (?))
                 union all
-                (select d.primary_kind, dck2.kind as for_kind, dcv.code, dcv.factory from device_class d,
+                (select d.primary_kind, d.name, d.category, dck2.kind as for_kind, dcv.code, dcv.factory from device_class d,
                  device_class d2, device_class_kind dck2, device_code_version dcv, device_class_kind dck
                  where dck.device_id = d.id and d.id = dcv.device_id and
                  dcv.version = d.approved_version


### PR DESCRIPTION
We need to extract the name and category to generate the device
factory dynamically in case it is not stored in the database
(as it is the case for pre-database-migration devices)