### PR TITLE
Implement persistent Commandpedia likes

### DIFF
--- a/model/example.js
+++ b/model/example.js
@@ -74,6 +74,10 @@ module.exports = {
         return db.selectAll(client, "select * from example_utterances");
     },
 
+    // The ForUser variants of getCommands and getCommandsByFuzzySearch
+    // return an additional column, "liked", which is a boolean indicating
+    // whether the named user liked the given command or not
+    // They are used to color the hearts in Commandpedia, if the user is logged in
     getCommandsForUser(client, language, userId, start, end) {
         const query = `
             (select eu.id,eu.language,eu.type,eu.utterance,

--- a/model/example.js
+++ b/model/example.js
@@ -89,7 +89,7 @@ module.exports = {
              from (example_utterances eu, device_schema ds) left join organizations org on org.id = ds.owner
              where ds.id = eu.schema_id and type = 'thingpedia' and language = ? and ds.approved_version is not null
              and is_base
-            ) order by like_count desc,md5(utterance) asc`;
+            ) order by like_count desc,click_count desc,md5(utterance) asc`;
 
         if (start !== undefined && end !== undefined)
             return db.selectAll(client, `${query} limit ?,?`, [userId, language, userId, language, start, end + 1]);
@@ -120,7 +120,7 @@ module.exports = {
              from (example_utterances eu, device_schema ds) left join organizations org on org.id = ds.owner
              where eu.schema_id = ds.id and eu.is_base = 1 and eu.type = 'thingpedia' and language = ?
              and match kind_canonical against (?) and target_code <> ''
-            ) order by like_count desc,md5(utterance) asc`, [userId, language, `%${query}%`, `%${query}%`,
+            ) order by like_count desc,click_count desc,md5(utterance) asc`, [userId, language, `%${query}%`, `%${query}%`,
                 userId, language, regexp, userId, language, query]);
     },
 
@@ -137,7 +137,7 @@ module.exports = {
              from (example_utterances eu, device_schema ds) left join organizations org on org.id = ds.owner
              where ds.id = eu.schema_id and type = 'thingpedia' and language = ? and ds.approved_version is not null
              and is_base
-            ) order by like_count desc,md5(utterance) asc`;
+            ) order by like_count desc,click_count desc,md5(utterance) asc`;
 
         if (start !== undefined && end !== undefined)
             return db.selectAll(client, `${query} limit ?,?`, [language, language, start, end + 1]);
@@ -165,7 +165,7 @@ module.exports = {
              from (example_utterances eu, device_schema ds) left join organizations org on org.id = ds.owner
              where eu.schema_id = ds.id and eu.is_base = 1 and eu.type = 'thingpedia' and language = ?
              and match kind_canonical against (?) and target_code <> ''
-            ) order by like_count desc,md5(utterance) asc`, [language, `%${query}%`, `%${query}%`, language, regexp, language, query]);
+            ) order by like_count desc,click_count desc,md5(utterance) asc`, [language, `%${query}%`, `%${query}%`, language, regexp, language, query]);
     },
 
     getCheatsheet(client, language) {

--- a/model/migrations/e6ce32d-example_likes.sql
+++ b/model/migrations/e6ce32d-example_likes.sql
@@ -1,0 +1,13 @@
+DROP TABLE IF EXISTS `example_likes`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `example_likes` (
+  `example_id` int(11) NOT NULL AUTO_INCREMENT,
+  `user_id` int(11) NOT NULL,
+  PRIMARY KEY (`example_id`, `user_id`),
+  CONSTRAINT `example_likes_ibfk_1` FOREIGN KEY (`example_id`) REFERENCES `example_utterances` (`id`) ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT `example_likes_ibfk_2` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`) ON DELETE RESTRICT ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+ALTER TABLE `example_utterances` ADD `like_count` int(11) NOT NULL DEFAULT 0 AFTER `click_count`;

--- a/model/schema.sql
+++ b/model/schema.sql
@@ -437,6 +437,7 @@ CREATE TABLE `example_utterances` (
   `target_json` text COLLATE utf8_bin NOT NULL,
   `target_code` text COLLATE utf8mb4_bin NOT NULL,
   `click_count` int(11) NOT NULL DEFAULT 0,
+  `like_count` int(11) NOT NULL DEFAULT 0,
   `owner` int(11) DEFAULT NULL,
   PRIMARY KEY (`id`),
   KEY `schema_id` (`schema_id`),
@@ -445,6 +446,22 @@ CREATE TABLE `example_utterances` (
   KEY `owner` (`owner`),
   CONSTRAINT `example_utterances_ibfk_1` FOREIGN KEY (`schema_id`) REFERENCES `device_schema` (`id`) ON DELETE CASCADE ON UPDATE CASCADE,
   CONSTRAINT `example_utterances_ibfk_2` FOREIGN KEY (`owner`) REFERENCES `users` (`id`) ON DELETE SET NULL ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Table structure for table `example_likes`
+--
+
+DROP TABLE IF EXISTS `example_likes`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `example_likes` (
+  `example_id` int(11) NOT NULL AUTO_INCREMENT,
+  `user_id` int(11) NOT NULL,
+  PRIMARY KEY (`example_id`, `user_id`),
+  CONSTRAINT `example_likes_ibfk_1` FOREIGN KEY (`example_id`) REFERENCES `example_utterances` (`id`) ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT `example_likes_ibfk_2` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`) ON DELETE RESTRICT ON UPDATE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin;
 /*!40101 SET character_set_client = @saved_cs_client */;
 

--- a/routes/thingpedia_api.js
+++ b/routes/thingpedia_api.js
@@ -1061,7 +1061,7 @@ v1.get('/commands/search', (req, res, next) => {
         if (req.user && isOriginOk(req))
             commands = await commandModel.getCommandsByFuzzySearchForUser(client, language, req.user.id, q);
         else
-            commands = await commandModel.getComgetCommandsByFuzzySearchmands(client, language, q);
+            commands = await commandModel.getCommandsByFuzzySearch(client, language, q);
 
         getCommandDetails(commands);
         res.cacheFor(30 * 1000);

--- a/routes/thingpedia_examples.js
+++ b/routes/thingpedia_examples.js
@@ -17,21 +17,21 @@ const db = require('../util/db');
 
 var router = express.Router();
 
-router.post('/upvote/:id', (req, res) => {
+router.post('/upvote/:id', user.requireLogIn, (req, res) => {
     db.withClient((dbClient) => {
-        return model.upvote(dbClient, req.params.id);
-    }).then(() => {
-        res.json({ result: 'ok' });
+        return model.like(dbClient, req.user.id, req.params.id);
+    }).then((liked) => {
+        res.json({ result: (liked ? 'ok' : 'no_change') });
     }, (e) => {
         res.status(400).json({ error: e.message });
     }).done();
 });
 
-router.post('/downvote/:id', (req, res) => {
+router.post('/downvote/:id', user.requireLogIn, (req, res) => {
     db.withClient((dbClient) => {
-        return model.downvote(dbClient, req.params.id);
-    }).then(() => {
-        res.json({ result: 'ok' });
+        return model.unlike(dbClient, req.user.id, req.params.id);
+    }).then((unliked) => {
+        res.json({ result: (unliked ? 'ok' : 'no_change') });
     }, (e) => {
         res.status(400).json({ error: e.message });
     }).done();

--- a/routes/user.js
+++ b/routes/user.js
@@ -15,6 +15,7 @@ const express = require('express');
 const passport = require('passport');
 
 const userUtils = require('../util/user');
+const exampleModel = require('../model/example');
 const model = require('../model/user');
 const db = require('../util/db');
 const SendMail = require('../util/sendmail');
@@ -254,10 +255,10 @@ router.post('/change-password', userUtils.requireLogIn, (req, res, next) => {
 });
 
 router.post('/delete', userUtils.requireLogIn, (req, res, next) => {
-    db.withTransaction((dbClient) => {
-        return EngineManager.get().deleteUser(req.user.id).then(() => {
-            return model.delete(dbClient, req.user.id);
-        });
+    db.withTransaction(async (dbClient) => {
+        await EngineManager.get().deleteUser(req.user.id);
+        await exampleModel.deleteAllLikesFromUser(dbClient, req.user.id);
+        await model.delete(dbClient, req.user.id);
     }).then(() => {
         req.logout();
         res.redirect(303, '/');

--- a/tests/data/test-examples-v1.json
+++ b/tests/data/test-examples-v1.json
@@ -6,6 +6,7 @@
     "utterance": "eat some data",
     "preprocessed": "eat some data",
     "target_code": "let action x := @org.thingpedia.builtin.test.eat_data();",
+    "like_count": 0,
     "click_count": 0
   },
   {
@@ -15,6 +16,7 @@
     "utterance": "get ${p_size} of data",
     "preprocessed": "get ${p_size} of data",
     "target_code": "let table x := \\(p_size : Measure(byte)) -> @org.thingpedia.builtin.test.get_data(size=p_size);",
+    "like_count": 0,
     "click_count": 7
   },
   {
@@ -24,6 +26,7 @@
     "utterance": "keep eating data!",
     "preprocessed": "keep eating data !",
     "target_code": "monitor (@org.thingpedia.builtin.test.get_data()) => @org.thingpedia.builtin.test.eat_data();",
+    "like_count": 0,
     "click_count": 0
   },
   {
@@ -33,6 +36,7 @@
     "utterance": "keep eating data! (v2)",
     "preprocessed": "keep eating data ! -lrb- v2 -rrb-",
     "target_code": " monitor (@org.thingpedia.builtin.test.get_data()) => @org.thingpedia.builtin.test.eat_data();",
+    "like_count": 0,
     "click_count": 0
   },
   {
@@ -42,6 +46,7 @@
     "utterance": "more data eating...",
     "preprocessed": "more data eating ...",
     "target_code": "let action x := @org.thingpedia.builtin.test.eat_data();",
+    "like_count": 0,
     "click_count": 0
   },
   {
@@ -51,6 +56,7 @@
     "utterance": "more data genning...",
     "preprocessed": "more data genning ...",
     "target_code": "let table _ := @org.thingpedia.builtin.test.get_data();",
+    "like_count": 0,
     "click_count": 0
   }
 ]

--- a/tests/data/test-examples-v3.json
+++ b/tests/data/test-examples-v3.json
@@ -6,6 +6,7 @@
         "utterance": "eat some data",
         "preprocessed": "eat some data",
         "target_code": "let action x := @org.thingpedia.builtin.test.eat_data();",
+        "like_count": 0,
         "click_count": 0
     },
     {
@@ -15,6 +16,7 @@
         "utterance": "get ${p_size} of data",
         "preprocessed": "get ${p_size} of data",
         "target_code": "let query x := \\(p_size : Measure(byte)) -> @org.thingpedia.builtin.test.get_data(size=p_size);",
+        "like_count": 0,
         "click_count": 7
     },
     {
@@ -24,6 +26,7 @@
         "utterance": "keep eating data!",
         "preprocessed": "keep eating data !",
         "target_code": "monitor (@org.thingpedia.builtin.test.get_data()) => @org.thingpedia.builtin.test.eat_data();",
+        "like_count": 0,
         "click_count": 0
     },
     {
@@ -33,6 +36,7 @@
         "utterance": "keep eating data! (v2)",
         "preprocessed": "keep eating data ! -lrb- v2 -rrb-",
         "target_code": " monitor (@org.thingpedia.builtin.test.get_data()) => @org.thingpedia.builtin.test.eat_data();",
+        "like_count": 0,
         "click_count": 0
     },
     {
@@ -42,6 +46,7 @@
         "utterance": "more data eating...",
         "preprocessed": "more data eating ...",
         "target_code": "let action x := @org.thingpedia.builtin.test.eat_data();",
+        "like_count": 0,
         "click_count": 0
     },
     {
@@ -51,6 +56,7 @@
         "utterance": "more data genning...",
         "preprocessed": "more data genning ...",
         "target_code": "let table _ := @org.thingpedia.builtin.test.get_data();",
+        "like_count": 0,
         "click_count": 0
     }
 ]

--- a/tests/load_test_thingpedia.js
+++ b/tests/load_test_thingpedia.js
@@ -203,6 +203,8 @@ async function loadExamples(dbClient, bob) {
     },
 
     ]);
+
+    await exampleModel.like(dbClient, bob.id, 999);
 }
 
 async function main() {

--- a/tests/test_thingpedia_api_v3.js
+++ b/tests/test_thingpedia_api_v3.js
@@ -29,8 +29,9 @@ assert.strictEqual(Config.THINGPEDIA_URL, '/thingpedia');
 }*/
 
 const THINGPEDIA_URL = 'http://127.0.0.1:8080/thingpedia/api/v3';
-async function request(url) {
-    const result = await Tp.Helpers.Http.get(THINGPEDIA_URL + url, { accept: 'application/json' });
+async function request(url, options = {}) {
+    options.accept = 'application/json';
+    const result = await Tp.Helpers.Http.get(THINGPEDIA_URL + url, options);
     //console.log(result);
     return JSON.parse(result);
 }
@@ -495,6 +496,8 @@ function checkExamples(generated, expected) {
         assert.strictEqual(typeof gen.preprocessed, 'string');
         assert.strictEqual(typeof gen.click_count, 'number');
         assert(gen.click_count >= 0);
+        assert.strictEqual(typeof gen.like_count, 'number');
+        assert(gen.like_count >= 0);
     }
 }
 function checkExamplesByKey(generated, key) {
@@ -514,6 +517,8 @@ function checkExamplesByKey(generated, key) {
         ThingTalk.Grammar.parse(gen.target_code);
         assert.strictEqual(typeof gen.click_count, 'number');
         assert(gen.click_count >= 0);
+        assert.strictEqual(typeof gen.like_count, 'number');
+        assert(gen.like_count >= 0);
     }
 }
 
@@ -550,23 +555,23 @@ async function testGetExamplesByDevice() {
     action  := @org.thingpedia.builtin.test.eat_data()
     #_[utterances=["eat some data"]]
     #_[preprocessed=["eat some data"]]
-    #[id=1000] #[click_count=0];
+    #[id=1000] #[click_count=0] #[like_count=0];
     query (p_size :Measure(byte))  := @org.thingpedia.builtin.test.get_data(size=p_size)
     #_[utterances=["get ${'${p_size}'} of data"]]
     #_[preprocessed=["get ${'${p_size}'} of data"]]
-    #[id=1001] #[click_count=7];
+    #[id=1001] #[click_count=7] #[like_count=0];
     program := monitor (@org.thingpedia.builtin.test.get_data()) => @org.thingpedia.builtin.test.eat_data()
     #_[utterances=["keep eating data!","keep eating data! (v2)"]]
     #_[preprocessed=["keep eating data !","keep eating data ! -lrb- v2 -rrb-"]]
-    #[id=1002] #[click_count=0];
+    #[id=1002] #[click_count=0] #[like_count=0];
     action () := @org.thingpedia.builtin.test.eat_data()
     #_[utterances=["more data eating..."]]
     #_[preprocessed=["more data eating ..."]]
-    #[id=1004] #[click_count=0];
+    #[id=1004] #[click_count=0] #[like_count=0];
     query  := @org.thingpedia.builtin.test.get_data()
     #_[utterances=["more data genning..."]]
     #_[preprocessed=["more data genning ..."]]
-    #[id=1005] #[click_count=0];
+    #[id=1005] #[click_count=0] #[like_count=0];
 }`);
 }
 
@@ -590,23 +595,23 @@ async function testGetExamplesByKey() {
     action  := @org.thingpedia.builtin.test.eat_data()
     #_[utterances=["eat some data"]]
     #_[preprocessed=["eat some data"]]
-    #[id=1000] #[click_count=0];
+    #[id=1000] #[click_count=0] #[like_count=0];
     query (p_size :Measure(byte))  := @org.thingpedia.builtin.test.get_data(size=p_size)
     #_[utterances=["get ${'${p_size}'} of data"]]
     #_[preprocessed=["get ${'${p_size}'} of data"]]
-    #[id=1001] #[click_count=7];
+    #[id=1001] #[click_count=7] #[like_count=0];
     program := monitor (@org.thingpedia.builtin.test.get_data()) => @org.thingpedia.builtin.test.eat_data()
     #_[utterances=["keep eating data!","keep eating data! (v2)"]]
     #_[preprocessed=["keep eating data !","keep eating data ! -lrb- v2 -rrb-"]]
-    #[id=1002] #[click_count=0];
+    #[id=1002] #[click_count=0] #[like_count=0];
     action () := @org.thingpedia.builtin.test.eat_data()
     #_[utterances=["more data eating..."]]
     #_[preprocessed=["more data eating ..."]]
-    #[id=1004] #[click_count=0];
+    #[id=1004] #[click_count=0] #[like_count=0];
     query  := @org.thingpedia.builtin.test.get_data()
     #_[utterances=["more data genning..."]]
     #_[preprocessed=["more data genning ..."]]
-    #[id=1005] #[click_count=0];
+    #[id=1005] #[click_count=0] #[like_count=0];
 }`);
 }
 
@@ -619,6 +624,8 @@ async function testGetCommands() {
         "preprocessed":"every day at TIME_0 set my laptop background to pizza images",
         "target_code":"( attimer time = TIME_0 ) join ( @com.bing.image_search param:query:String = \" pizza \" ) => @org.thingpedia.builtin.thingengine.gnome.set_background on  param:picture_url:Entity(tt:picture) = param:picture_url:Entity(tt:picture)",
         "click_count":8,
+        "like_count": 1,
+        "liked": true,
         "is_base": 0,
         "owner_name":"bob",
         "devices":["com.bing","org.thingpedia.builtin.thingengine.gnome"]
@@ -631,6 +638,8 @@ async function testGetCommands() {
       "preprocessed": "get ${p_size} of data",
       "target_code": "let query x := \\(p_size : Measure(byte)) -> @org.thingpedia.builtin.test.get_data(size=p_size);",
       "click_count": 7,
+      "like_count": 0,
+      "liked": false,
       "is_base": 1,
       "owner_name": "Site Administration",
       "devices": [
@@ -645,6 +654,8 @@ async function testGetCommands() {
       "preprocessed": "images from bing matching ${p_query} larger than ${p_width} x ${p_height}",
       "target_code": "query (p_query :String, p_width :Number, p_height :Number)  := (@com.bing.image_search(query=p_query)), (width >= p_width && height >= p_height);\n",
       "click_count": 1,
+      "like_count": 0,
+      "liked": false,
       "is_base": 1,
       "owner_name": "Test Org",
       "devices": [
@@ -659,6 +670,8 @@ async function testGetCommands() {
       "preprocessed": "open the file at ${p_url}",
       "target_code": "action (p_url :Entity(tt:url))  := @org.thingpedia.builtin.thingengine.builtin.open_url(url=p_url);\n",
       "click_count": 1,
+      "like_count": 0,
+      "liked": false,
       "is_base": 1,
       "owner_name": "Site Administration",
       "devices": [
@@ -673,6 +686,8 @@ async function testGetCommands() {
       "preprocessed": "texts i received in the last hour",
       "target_code": "query  := (@org.thingpedia.builtin.thingengine.phone.sms()), date >= start_of(h);\n",
       "click_count": 1,
+      "like_count": 0,
+      "liked": false,
       "is_base": 1,
       "owner_name": "Site Administration",
       "devices": [
@@ -687,6 +702,8 @@ async function testGetCommands() {
       "preprocessed": "call somebody",
       "target_code": "action  := @org.thingpedia.builtin.thingengine.phone.call(number=$undefined);\n",
       "click_count": 1,
+      "like_count": 0,
+      "liked": false,
       "is_base": 1,
       "owner_name": "Site Administration",
       "devices": [
@@ -701,6 +718,8 @@ async function testGetCommands() {
       "preprocessed": ", throw a dice between ${p_low:const} and ${p_high:const}",
       "target_code": "query (p_low :Number, p_high :Number)  := @org.thingpedia.builtin.thingengine.builtin.get_random_between(low=p_low, high=p_high);\n",
       "click_count": 1,
+      "like_count": 0,
+      "liked": false,
       "is_base": 1,
       "owner_name": "Site Administration",
       "devices": [
@@ -715,6 +734,8 @@ async function testGetCommands() {
       "preprocessed": "a screenshot of my laptop",
       "target_code": "query  := @org.thingpedia.builtin.thingengine.gnome.get_screenshot();\n",
       "click_count": 1,
+      "like_count": 0,
+      "liked": false,
       "is_base": 1,
       "owner_name": "Site Administration",
       "devices": [
@@ -729,6 +750,8 @@ async function testGetCommands() {
       "preprocessed": ", generate a random number between ${p_low:const} and ${p_high:const}",
       "target_code": "query (p_low :Number, p_high :Number)  := @org.thingpedia.builtin.thingengine.builtin.get_random_between(low=p_low, high=p_high);\n",
       "click_count": 1,
+      "like_count": 0,
+      "liked": false,
       "is_base": 1,
       "owner_name": "Site Administration",
       "devices": [
@@ -743,6 +766,8 @@ async function testGetCommands() {
       "preprocessed": "setup ${p_device}",
       "target_code": "action (p_device :Entity(tt:device))  := @org.thingpedia.builtin.thingengine.builtin.configure(device=p_device);\n",
       "click_count": 1,
+      "like_count": 0,
+      "liked": false,
       "is_base": 1,
       "owner_name": "Site Administration",
       "devices": [
@@ -751,9 +776,41 @@ async function testGetCommands() {
     }
   ];
 
+    // first test with no cookie: there should be no `liked` field
     assert.deepStrictEqual(await request('/commands/all'), {
         result: 'ok',
+        data: TEST_DATA.map((command) => {
+            const clone = {};
+            Object.assign(clone, command);
+            delete clone.liked;
+            return clone;
+        })
+    });
+
+    // now test with cookie and valid origin
+    assert.deepStrictEqual(await request('/commands/all', {
+        extraHeaders: {
+            'Cookie': process.env.COOKIE,
+            'Origin': Config.SERVER_ORIGIN,
+        }
+    }), {
+        result: 'ok',
         data: TEST_DATA
+    });
+
+    // now with cookie and invalid origin (csrf attack)
+    assert.deepStrictEqual(await request('/commands/all', {
+        extraHeaders: {
+            'Cookie': process.env.COOKIE,
+        }
+    }), {
+        result: 'ok',
+        data: TEST_DATA.map((command) => {
+            const clone = {};
+            Object.assign(clone, command);
+            delete clone.liked;
+            return clone;
+        })
     });
 
     assert.deepStrictEqual(await request('/commands/search?q=laptop'), {
@@ -767,6 +824,7 @@ async function testGetCommands() {
       "preprocessed": "every day at TIME_0 set my laptop background to pizza images",
       "target_code": "( attimer time = TIME_0 ) join ( @com.bing.image_search param:query:String = \" pizza \" ) => @org.thingpedia.builtin.thingengine.gnome.set_background on  param:picture_url:Entity(tt:picture) = param:picture_url:Entity(tt:picture)",
       "click_count": 8,
+      "like_count": 1,
       "is_base": 0,
       "owner_name": "bob",
       "devices": [
@@ -782,6 +840,7 @@ async function testGetCommands() {
       "preprocessed": "a screenshot of my laptop",
       "target_code": "query  := @org.thingpedia.builtin.thingengine.gnome.get_screenshot();\n",
       "click_count": 1,
+      "like_count": 0,
       "is_base": 1,
       "owner_name": "Site Administration",
       "devices": [
@@ -796,6 +855,7 @@ async function testGetCommands() {
       "preprocessed": "create a file named ${p_file_name:const} on my laptop",
       "target_code": "action (p_file_name :Entity(tt:path_name))  := @org.thingpedia.builtin.thingengine.gnome.create_file(file_name=p_file_name, contents=$undefined);\n",
       "click_count": 1,
+      "like_count": 0,
       "is_base": 1,
       "owner_name": "Site Administration",
       "devices": [
@@ -810,6 +870,7 @@ async function testGetCommands() {
       "preprocessed": "turn ${p_power} my laptop",
       "target_code": "action (p_power :Enum(on,off))  := @org.thingpedia.builtin.thingengine.gnome.set_power(power=p_power);\n",
       "click_count": 1,
+      "like_count": 0,
       "is_base": 1,
       "owner_name": "Site Administration",
       "devices": [
@@ -824,6 +885,7 @@ async function testGetCommands() {
       "preprocessed": "delete a file from my laptop",
       "target_code": "action  := @org.thingpedia.builtin.thingengine.gnome.delete_file(file_name=$undefined);\n",
       "click_count": 1,
+      "like_count": 0,
       "is_base": 1,
       "owner_name": "Site Administration",
       "devices": [
@@ -838,6 +900,7 @@ async function testGetCommands() {
       "preprocessed": "use ${p_picture_url} as the background of my laptop",
       "target_code": "action (p_picture_url :Entity(tt:picture))  := @org.thingpedia.builtin.thingengine.gnome.set_background(picture_url=p_picture_url);\n",
       "click_count": 1,
+      "like_count": 0,
       "is_base": 1,
       "owner_name": "Site Administration",
       "devices": [
@@ -852,6 +915,7 @@ async function testGetCommands() {
       "preprocessed": ", save a screenshot of my laptop",
       "target_code": "query  := @org.thingpedia.builtin.thingengine.gnome.get_screenshot();\n",
       "click_count": 1,
+      "like_count": 0,
       "is_base": 1,
       "owner_name": "Site Administration",
       "devices": [
@@ -866,6 +930,7 @@ async function testGetCommands() {
       "preprocessed": "lock my laptop",
       "target_code": "action  := @org.thingpedia.builtin.thingengine.gnome.lock();\n",
       "click_count": 1,
+      "like_count": 0,
       "is_base": 1,
       "owner_name": "Site Administration",
       "devices": [
@@ -880,6 +945,7 @@ async function testGetCommands() {
       "preprocessed": "set the background of my laptop to ${p_picture_url}",
       "target_code": "action (p_picture_url :Entity(tt:picture))  := @org.thingpedia.builtin.thingengine.gnome.set_background(picture_url=p_picture_url);\n",
       "click_count": 1,
+      "like_count": 0,
       "is_base": 1,
       "owner_name": "Site Administration",
       "devices": [
@@ -894,6 +960,7 @@ async function testGetCommands() {
       "preprocessed": "change the background on my laptop",
       "target_code": "action  := @org.thingpedia.builtin.thingengine.gnome.set_background(picture_url=$undefined);\n",
       "click_count": 1,
+      "like_count": 0,
       "is_base": 1,
       "owner_name": "Site Administration",
       "devices": [
@@ -908,6 +975,7 @@ async function testGetCommands() {
       "preprocessed": "create a file named ${p_file_name:const} on my laptop containing ${p_contents}",
       "target_code": "action (p_file_name :Entity(tt:path_name), p_contents :String)  := @org.thingpedia.builtin.thingengine.gnome.create_file(file_name=p_file_name, contents=p_contents);\n",
       "click_count": 1,
+      "like_count": 0,
       "is_base": 1,
       "owner_name": "Site Administration",
       "devices": [
@@ -922,6 +990,7 @@ async function testGetCommands() {
       "preprocessed": "open ${p_app_id} on my laptop",
       "target_code": "action (p_app_id :Entity(org.freedesktop:app_id))  := @org.thingpedia.builtin.thingengine.gnome.open_app(app_id=p_app_id);\n",
       "click_count": 1,
+      "like_count": 0,
       "is_base": 1,
       "owner_name": "Site Administration",
       "devices": [
@@ -936,6 +1005,7 @@ async function testGetCommands() {
       "preprocessed": "delete the file named ${p_file_name:const} from my laptop",
       "target_code": "action (p_file_name :Entity(tt:path_name))  := @org.thingpedia.builtin.thingengine.gnome.delete_file(file_name=p_file_name);\n",
       "click_count": 1,
+      "like_count": 0,
       "is_base": 1,
       "owner_name": "Site Administration",
       "devices": [
@@ -950,6 +1020,7 @@ async function testGetCommands() {
       "preprocessed": ", take a screenshot of my laptop",
       "target_code": "query  := @org.thingpedia.builtin.thingengine.gnome.get_screenshot();\n",
       "click_count": 1,
+      "like_count": 0,
       "is_base": 1,
       "owner_name": "Site Administration",
       "devices": [
@@ -964,6 +1035,7 @@ async function testGetCommands() {
       "preprocessed": "open ${p_url} with ${p_app_id} on my laptop",
       "target_code": "action (p_url :Entity(tt:url), p_app_id :Entity(org.freedesktop:app_id))  := @org.thingpedia.builtin.thingengine.gnome.open_app(app_id=p_app_id, url=p_url);\n",
       "click_count": 1,
+      "like_count": 0,
       "is_base": 1,
       "owner_name": "Site Administration",
       "devices": [
@@ -978,6 +1050,7 @@ async function testGetCommands() {
       "preprocessed": "delete ${p_file_name} from my laptop",
       "target_code": "action (p_file_name :Entity(tt:path_name))  := @org.thingpedia.builtin.thingengine.gnome.delete_file(file_name=p_file_name);\n",
       "click_count": 1,
+      "like_count": 0,
       "is_base": 1,
       "owner_name": "Site Administration",
       "devices": [
@@ -992,6 +1065,7 @@ async function testGetCommands() {
       "preprocessed": "activate the lock screen on my laptop",
       "target_code": "action  := @org.thingpedia.builtin.thingengine.gnome.lock();\n",
       "click_count": 1,
+      "like_count": 0,
       "is_base": 1,
       "owner_name": "Site Administration",
       "devices": [

--- a/tests/thingpedia-integration.sh
+++ b/tests/thingpedia-integration.sh
@@ -68,7 +68,11 @@ else
     sleep 30
 
     node $srcdir/tests/test_thingpedia_api_v1_v2.js
-    node $srcdir/tests/test_thingpedia_api_v3.js
+
+    # login as bob
+    bob_cookie=$(node $srcdir/tests/login.js bob 12345678)
+
+    COOKIE="${bob_cookie}" node $srcdir/tests/test_thingpedia_api_v3.js
 fi
 
 kill $frontendpid

--- a/util/dataset.js
+++ b/util/dataset.js
@@ -97,7 +97,8 @@ function rowsToExamples(rows, { editMode = false}) {
                 id: row.id,
                 utterances: [row.utterance],
                 preprocessed: [row.preprocessed],
-                click_count: row.click_count
+                click_count: row.click_count,
+                like_count: row.like_count,
             });
         }
     }
@@ -125,7 +126,7 @@ function rowsToExamples(rows, { editMode = false}) {
             buffer.push(`    ${targetCode}
     #_[utterances=[${ex.utterances.map(stringEscape)}]]
     #_[preprocessed=[${ex.preprocessed.map(stringEscape)}]]
-    #[id=${ex.id}] #[click_count=${ex.click_count}];
+    #[id=${ex.id}] #[click_count=${ex.click_count}] #[like_count=${ex.like_count}];
 `);
         }
     }

--- a/util/db.js
+++ b/util/db.js
@@ -142,6 +142,12 @@ module.exports = {
         });
     },
 
+    insertIgnore(client, string, args) {
+        return query(client, string, args).then(([result, fields]) => {
+            return result.affectedRows > 0;
+        });
+    },
+
     selectOne,
     selectAll,
     query


### PR DESCRIPTION
Duplicate likes are now ignored, and the user must be logged in to like an example. If you click on a like and you are not logged in, you are redirected to a login page.

Fixes #118