### PR TITLE
Use cloud_id instead of id for users in Commandpedia & Train Almond

### DIFF
--- a/browser/deps/new-command.js
+++ b/browser/deps/new-command.js
@@ -22,9 +22,9 @@ module.exports = class ThingTalkTrainer {
 
         this.parser = new ParserClient(options.sempreUrl, 'en-US');
 
-        this._locale = $('body[data-locale]').attr('data-locale');
-        this._developerKey = $('body[data-developer-key]').attr('data-developer-key') || null;
-        this._user = $('body[data-user-id]').attr('data-user-id') || null;
+        this._locale = document.body.dataset.locale;
+        this._developerKey = document.body.dataset.developerKey || null;
+        this._user = document.body.dataset.cloudId || null;
 
         this.thingpedia = new ThingpediaClient(this._developerKey, this._locale);
         this._schemaRetriever = new SchemaRetriever(this.thingpedia);

--- a/browser/trainer.js
+++ b/browser/trainer.js
@@ -26,8 +26,9 @@ class ThingTalkTrainer {
     constructor(sempreUrl) {
         this.parser = new ParserClient(sempreUrl, 'en-US');
 
-        this._locale = $('body[data-locale]').attr('data-locale');
-        this._developerKey = $('body[data-developer-key]').attr('data-developer-key') || null;
+        this._locale = document.body.dataset.locale;
+        this._developerKey = document.body.dataset.developerKey || null;
+        this._user = document.body.dataset.cloudId || null;
 
         this.thingpedia = new ThingpediaClient(this._developerKey, this._locale);
         this._schemaRetriever = new SchemaRetriever(this.thingpedia);
@@ -206,7 +207,7 @@ class ThingTalkTrainer {
     }
 
     _learnNN(targetCode) {
-        return this.parser.onlineLearn(this._raw, targetCode, 'online');
+        return this.parser.onlineLearn(this._raw, targetCode, 'online', this._user);
     }
 
     _learnThingTalk(text) {
@@ -217,7 +218,7 @@ class ThingTalkTrainer {
         const raw = this._raw;
         return ThingTalk.Grammar.parseAndTypecheck(text, this._schemaRetriever).then((program) => {
             const code = this._toNN(program);
-            return this.parser.onlineLearn(raw, code, 'online');
+            return this.parser.onlineLearn(raw, code, 'online', this._user);
         });
     }
 

--- a/views/layout.pug
+++ b/views/layout.pug
@@ -22,7 +22,7 @@ html
   - var stdlayout = true;
   - var includefooter = true;
   body(data-icon-cdn=CDN_HOST, data-developer-key=authenticated ? user.developer_key : false,
-       data-locale=locale, data-thingpedia-url=THINGPEDIA_URL, data-user-id=user.id,
+       data-locale=locale, data-thingpedia-url=THINGPEDIA_URL, data-cloud-id=user.cloud_id,
        data-csrf-token=csrfToken)
     nav.navbar-inverse.navbar.navbar-fixed-top(role="banner")
       div.navbar-header


### PR DESCRIPTION
Sequential user IDs leak the number of registered users, and should never be revealed. Cloud IDs are randomized and have no such problem.
Also, because cloud IDs are not predictable, this offers a marginal improvement in security, as it becomes harder to fake a command contribution and attribute it to somebody else.

Depends on the corresponding fix in almond-nnparser.