### PR TITLE
A refresher & update of the Web Almond API

### DIFF
--- a/almond/almond_api.js
+++ b/almond/almond_api.js
@@ -28,8 +28,13 @@ module.exports = class AlmondApi {
 
     _sendWs(obj) {
         let str = JSON.stringify(obj);
-        for (let out of this._outputs)
-            out.send(str);
+        for (let out of this._outputs) {
+            try {
+                out.send(str);
+            } catch(e) {
+                // ignore errors if the connection was closed, while still sending to other connections
+            }
+        }
     }
     addOutput(out) {
         this._outputs.add(out);
@@ -189,7 +194,7 @@ module.exports = class AlmondApi {
                 return this._doParse(sentence);
             }
         }).then((analyzed) => {
-            return Promise.all(analyzed.candidates.slice(0, 3).map((candidate) => {
+            return Promise.all(analyzed.candidates.map((candidate) => {
                 return this._processCandidate(candidate, analyzed);
             })).then((programs) => {
                 return programs.filter((r) => r !== null);
@@ -197,7 +202,7 @@ module.exports = class AlmondApi {
                 return {
                     tokens: analyzed.tokens,
                     entities: analyzed.entities,
-                    candidates: programs
+                    candidates: programs.slice(0, 3)
                 };
             });
         });

--- a/public/javascripts/profile.js
+++ b/public/javascripts/profile.js
@@ -1,11 +1,22 @@
-(function() {
-    $(function() {
-        var text = $('#qrcode-target').text();
-        new QRCode('qrcode-placeholder', text);
+"use strict";
+$(function() {
+    var text = $('#qrcode-target').text();
+    new QRCode('qrcode-placeholder', text);
 
-        if (navigator.userAgent.match(/android/i)) {
-            $('#config-phone-desktop-browser').hide();
-            $('#config-phone-mobile-browser').show();
-        }
+    if (navigator.userAgent.match(/android/i)) {
+        $('#config-phone-desktop-browser').hide();
+        $('#config-phone-mobile-browser').show();
+    }
+
+    $('#issue-token-form').submit(function(event) {
+        event.preventDefault();
+
+        var csrfToken = document.body.dataset.csrfToken;
+        $.ajax('/me/api/token', { data: { _csrf: csrfToken }, method: 'POST' }).then(function(response) {
+            $('#issue-token-result').removeClass('hidden');
+            $('#issue-token-result-placeholder').text(response.token);
+        }, function (err) {
+            console.error(err);
+        });
     });
-})();
+});

--- a/routes/my_api.js
+++ b/routes/my_api.js
@@ -13,12 +13,13 @@ const Q = require('q');
 const express = require('express');
 const crypto = require('crypto');
 const passport = require('passport');
-
-const Config = require('../config');
+const jwt = require('jsonwebtoken');
 
 const user = require('../util/user');
+const secret = require('../util/secret_key');
 const EngineManager = require('../almond/enginemanagerclient');
 
+const Config = require('../config');
 
 function makeRandom(bytes) {
     return crypto.randomBytes(bytes).toString('hex');
@@ -32,7 +33,7 @@ function isOriginOk(req) {
     if (req.headers['authorization'] && req.headers['authorization'].startsWith('Bearer '))
         return true;
     if (typeof req.headers['origin'] !== 'string')
-        return false;
+        return true;
     return ALLOWED_ORIGINS.indexOf(req.headers['origin'].toLowerCase()) >= 0;
 }
 
@@ -57,6 +58,20 @@ router.ws('/anonymous', (ws, req) => {
 
     user.getAnonymousUser().then((user) => {
         return doConversation(user, true, ws);
+    });
+});
+
+router.post('/token', user.requireLogIn, (req, res, next) => {
+    // issue an access token for valid for one month, with all scopes
+    jwt.sign({
+        sub: req.user.cloud_id,
+        aud: 'oauth2',
+        scope: Array.from(user.OAuthScopes)
+    }, secret.getJWTSigningKey(), { expiresIn: 30*24*3600 }, (err, token) => {
+        if (err)
+            next(err);
+        else
+            res.json({ result: 'ok', token });
     });
 });
 

--- a/routes/my_api.js
+++ b/routes/my_api.js
@@ -61,7 +61,7 @@ router.ws('/anonymous', (ws, req) => {
 });
 
 router.use((req, res, next) => {
-    if (req.user) {
+    if (user.isAuthenticated(req)) {
         next();
         return;
     }

--- a/routes/my_api.js
+++ b/routes/my_api.js
@@ -87,6 +87,19 @@ router.options('/.*', (req, res, next) => {
     res.send('');
 });
 
+router.get('/profile', user.requireScope('profile'), (req, res, next) => {
+    res.json({
+        id: req.user.cloud_id,
+        username: req.user.username,
+        full_name: req.user.human_name,
+        email: req.user.email,
+        email_verified: req.user.email_verified,
+        locale: req.user.locale,
+        timezone: req.user.timezone,
+        model_tag: req.user.model_tag
+    });
+});
+
 router.get('/parse', user.requireScope('user-read'), (req, res, next) => {
     let query = req.query.q || null;
     let targetJson = req.query.target_json || null;

--- a/tests/test_website_basic.js
+++ b/tests/test_website_basic.js
@@ -8,3 +8,265 @@
 //
 // See COPYING for details
 "use strict";
+
+const Q = require('q');
+Q.longStackSupport = true;
+require('thingengine-core/lib/polyfill');
+require('./polyfill');
+process.on('unhandledRejection', (up) => { throw up; });
+
+const assert = require('assert');
+const WebSocket = require('ws');
+const Tp = require('thingpedia');
+const ThingTalk = require('thingtalk');
+
+const Config = require('../config');
+
+const csrf = require('./util/csrf');
+
+const db = require('../util/db');
+
+function dbQuery(query, args) {
+    return db.withClient((dbClient) => {
+        return db.selectOne(dbClient, query, args);
+    });
+}
+
+function request(url, method, data, options = {}) {
+    options['user-agent'] = 'Thingpedia-Cloud-Test/1.0.0';
+
+    return Tp.Helpers.Http.request(Config.SERVER_ORIGIN + url, method, data, options);
+}
+
+function assertHttpError(request, httpStatus) {
+    return request.then(() => {
+        assert.fail(new Error(`Expected HTTP error`));
+    }, (err) => {
+        if (typeof err.code === 'number')
+            assert.deepStrictEqual(err.code, httpStatus);
+        else
+            throw err;
+    });
+}
+
+async function getAccessToken() {
+    const csrfToken = csrf.getCsrfToken(await request('/', 'GET', null, {
+        extraHeaders: { 'Cookie': process.env.COOKIE }
+    }));
+
+    return JSON.parse(await request('/me/api/token', 'POST', '_csrf=' + csrfToken, {
+        accept: 'application/json',
+        extraHeaders: { 'Cookie': process.env.COOKIE }
+    })).token;
+}
+
+async function testMyApiCookie() {
+    const result = JSON.parse(await request('/me/api/profile', 'GET', null, {
+        extraHeaders: { 'Cookie': process.env.COOKIE }
+    }));
+
+    const bobInfo = await dbQuery(`select * from users where username = ?`, ['bob']);
+
+    assert.deepStrictEqual(result, {
+        id: bobInfo.cloud_id,
+        username: 'bob',
+        full_name: bobInfo.human_name,
+        email: bobInfo.email,
+        email_verified: bobInfo.email_verified,
+        locale: bobInfo.locale,
+        timezone: bobInfo.timezone,
+        model_tag: bobInfo.model_tag
+    });
+
+    await assertHttpError(request('/me/api/profile', 'GET', null, {
+        extraHeaders: {
+            'Cookie': 'connect.sid=invalid',
+        }
+    }), 401);
+
+    await assertHttpError(request('/me/api/profile', 'GET', null, {
+        extraHeaders: {
+            'Cookie': process.env.COOKIE,
+            'Origin': 'https://invalid.origin.example.com'
+        }
+    }), 403);
+
+    await request('/me/api/profile', 'GET', null, {
+        extraHeaders: {
+            'Cookie': process.env.COOKIE,
+            'Origin': Config.SERVER_ORIGIN
+        }
+    });
+}
+
+async function testMyApiProfileOAuth(auth) {
+    const result = JSON.parse(await request('/me/api/profile', 'GET', null, { auth }));
+
+    const bobInfo = await dbQuery(`select * from users where username = ?`, ['bob']);
+
+    assert.deepStrictEqual(result, {
+        id: bobInfo.cloud_id,
+        username: 'bob',
+        full_name: bobInfo.human_name,
+        email: bobInfo.email,
+        email_verified: bobInfo.email_verified,
+        locale: bobInfo.locale,
+        timezone: bobInfo.timezone,
+        model_tag: bobInfo.model_tag
+    });
+}
+
+async function testMyApiParse(auth) {
+    const result = JSON.parse(await request('/me/api/parse?q=what+time+is+it', 'GET', null, { auth }));
+
+    assert.deepStrictEqual(result.tokens, ['what', 'time', 'is', 'it']);
+    assert.deepStrictEqual(result.entities, {});
+    assert(result.candidates.length > 0);
+
+    assert(!isNaN(parseFloat(result.candidates[0].score)));
+    ThingTalk.Grammar.parse(result.candidates[0].code);
+    assert.strictEqual(result.candidates[0].commandClass, 'query');
+    assert.strictEqual(typeof result.candidates[0].devices, 'object');
+    assert.strictEqual(typeof result.candidates[0].locations, 'object');
+}
+
+async function testMyApiCreateGetApp(auth) {
+    const result = JSON.parse(await request('/me/api/apps/create', 'POST', JSON.stringify({
+        code: `now => @org.thingpedia.builtin.test(id="org.thingpedia.builtin.test").get_data(count=2, size=10byte) => notify;`
+    }), { auth, dataContentType: 'application/json' }));
+
+    assert(result.uniqueId.startsWith('uuid-'));
+    assert.strictEqual(result.description, 'get generate 10 byte of fake data with count equal to 2 and then notify you');
+    assert.strictEqual(result.code, '{\n  now => @org.thingpedia.builtin.test(id="org.thingpedia.builtin.test").get_data(count=2, size=10byte) => notify;\n}');
+    assert.strictEqual(result.icon, '/download/icons/org.thingpedia.builtin.test.png');
+    assert.deepStrictEqual(result.errors, []);
+
+    assert.deepStrictEqual(result.results, [{
+        raw: {
+            count: 2,
+            data: '!!!!!!!!!!',
+            size: 10
+        },
+        formatted: ['!!!!!!!!!!'],
+        type: 'org.thingpedia.builtin.test:get_data'
+    }, {
+        raw: {
+            count: 2,
+            data: '""""""""""',
+            size: 10
+        },
+        formatted: ['""""""""""'],
+        type: 'org.thingpedia.builtin.test:get_data'
+    }]);
+}
+
+async function testMyApiCreateWhenApp(auth) {
+    const ws = new WebSocket(Config.SERVER_ORIGIN + '/me/api/results', {
+        headers: {
+            'Authorization': auth
+        }
+    });
+
+    const result = JSON.parse(await request('/me/api/apps/create', 'POST', JSON.stringify({
+        code: `monitor @org.thingpedia.builtin.test(id="org.thingpedia.builtin.test").get_data(size=10byte) => notify;`
+    }), { auth, dataContentType: 'application/json' }));
+
+    assert(result.uniqueId.startsWith('uuid-'));
+    assert.strictEqual(result.description, 'notify you when generate 10 byte of fake data change');
+    assert.strictEqual(result.code, '{\n  monitor (@org.thingpedia.builtin.test(id="org.thingpedia.builtin.test").get_data(size=10byte)) => notify;\n}');
+    assert.strictEqual(result.icon, '/download/icons/org.thingpedia.builtin.test.png');
+    assert.deepStrictEqual(result.results, []);
+    assert.deepStrictEqual(result.errors, []);
+
+    await new Promise((resolve, reject) => {
+        let count = 0;
+        ws.on('message', (data) => {
+            const parsed = JSON.parse(data);
+            if (parsed.result.appId !== result.uniqueId)
+                return;
+            delete parsed.result.raw.__timestamp;
+            if (count === 0) {
+                assert.deepStrictEqual(parsed, { result:
+                    { appId: result.uniqueId,
+                      raw: { data: '!!!!!!!!!!', size: 10 },
+                      type: 'org.thingpedia.builtin.test:get_data',
+                      formatted: [ '!!!!!!!!!!' ],
+                      icon: '/download/icons/org.thingpedia.builtin.test.png' }
+                });
+            } else {
+                assert.deepStrictEqual(parsed, { result:
+                    { appId: result.uniqueId,
+                      raw: { data: '""""""""""', size: 10 },
+                      type: 'org.thingpedia.builtin.test:get_data',
+                      formatted: [ '""""""""""' ],
+                      icon: '/download/icons/org.thingpedia.builtin.test.png' }
+                });
+            }
+            if (++count === 2) {
+                ws.close();
+                resolve();
+            }
+        });
+    });
+
+    return result.uniqueId;
+}
+
+async function testMyApiListApps(auth, uniqueId) {
+    const listResult = JSON.parse(await request('/me/api/apps/list', 'GET', null, { auth }));
+    assert.deepStrictEqual(listResult, [{
+        uniqueId,
+        description: 'notify you when generate 10 byte of fake data change',
+        error: null,
+        code:
+         '{\n  monitor (@org.thingpedia.builtin.test(id="org.thingpedia.builtin.test").get_data(size=10byte)) => notify;\n}',
+        slots: { '$icon': 'org.thingpedia.builtin.test' },
+        icon: '/download/icons/org.thingpedia.builtin.test.png'
+    }]);
+
+    const getResult = JSON.parse(await request('/me/api/apps/get/' + uniqueId, 'GET', null, { auth }));
+    assert.deepStrictEqual(getResult, {
+        uniqueId,
+        description: 'notify you when generate 10 byte of fake data change',
+        error: null,
+        code:
+         '{\n  monitor (@org.thingpedia.builtin.test(id="org.thingpedia.builtin.test").get_data(size=10byte)) => notify;\n}',
+        slots: { '$icon': 'org.thingpedia.builtin.test' },
+        icon: '/download/icons/org.thingpedia.builtin.test.png'
+    });
+
+    await assertHttpError(request('/me/api/apps/get/uuid-invalid', 'GET', null, { auth }), 404);
+}
+
+async function testMyApiDeleteApp(auth, uniqueId) {
+    const result = JSON.parse(await request('/me/api/apps/delete/' + uniqueId, 'POST', '', { auth }));
+    assert.deepStrictEqual(result, { status: 'ok' });
+
+    const listResult = JSON.parse(await request('/me/api/apps/list', 'GET', null, { auth }));
+    assert.deepStrictEqual(listResult, []);
+
+    await assertHttpError(request('/me/api/apps/delete/uuid-invalid', 'POST', '', { auth }), 404);
+}
+
+async function testMyApiOAuth(accessToken) {
+    const auth = 'Bearer ' + accessToken;
+
+    // /profile
+    await testMyApiProfileOAuth(auth);
+    await testMyApiParse(auth);
+    await testMyApiCreateGetApp(auth);
+    const uniqueId = await testMyApiCreateWhenApp(auth);
+    await testMyApiListApps(auth, uniqueId);
+    await testMyApiDeleteApp(auth, uniqueId);
+}
+
+async function main() {
+    await testMyApiCookie();
+
+    const token = await getAccessToken();
+
+    await testMyApiOAuth(token);
+
+    await db.tearDown();
+}
+main();

--- a/tests/thingpedia-integration.sh
+++ b/tests/thingpedia-integration.sh
@@ -114,7 +114,7 @@ else
     COOKIE="${root_cookie}" node $srcdir/tests/linkcheck.js
 
     # test the website by making HTTP requests directly
-    node $srcdir/tests/test_website_basic.js
+    COOKIE="${bob_cookie}" node $srcdir/tests/test_website_basic.js
 
     # test the website in a browser
     SELENIUM_BROWSER=firefox node $srcdir/tests/test_website_selenium.js

--- a/tests/util/csrf.js
+++ b/tests/util/csrf.js
@@ -1,0 +1,19 @@
+// -*- mode: js; indent-tabs-mode: nil; js-basic-offset: 4 -*-
+//
+// This file is part of Almond Cloud
+//
+// Copyright 2018 The Board of Trustees of the Leland Stanford Junior University
+//
+// Author: Giovanni Campagna <gcampagn@cs.stanford.edu>
+//
+// See COPYING for details
+"use strict";
+
+const minidom = require('./minidom');
+
+function getCsrfToken(htmlString) {
+    const [body] = minidom.getElementsByTagName(minidom.parse(htmlString), 'body');
+    return minidom.getAttribute(body, 'data-csrf-token');
+}
+
+module.exports = { getCsrfToken };

--- a/tests/webalmond-integration.sh
+++ b/tests/webalmond-integration.sh
@@ -73,7 +73,7 @@ else
     COOKIE="${root_cookie}" node $srcdir/tests/linkcheck.js
 
     # test the website by making HTTP requests directly
-    node $srcdir/tests/test_website_basic.js
+    COOKIE="${bob_cookie}" node $srcdir/tests/test_website_basic.js
 
     # test the website in a browser
     SELENIUM_BROWSER=firefox node $srcdir/tests/test_website_selenium.js

--- a/views/user_profile.pug
+++ b/views/user_profile.pug
@@ -221,6 +221,17 @@ block content
       div.panel-body
         p= _("You have not authorized any third-party app.")
 
+    if user.developer_org !== null
+      div.panel-footer
+        p
+          form(action='/me/api/generate-token',method='post')#issue-token-form
+            input(type='hidden', name='_csrf', value=csrfToken)
+            button(type='submit').btn.btn-primary= _("Issue an Access Token")
+        div#issue-token-result.hidden
+          p= _("The following token is valid anywhere an access token is expected. It is valid for one month, and enables all scopes. Treat it like a password!")
+          pre
+            code#issue-token-result-placeholder
+
   div.panel.panel-default
     div.panel-heading
       h2.panel-title= _("Phone")


### PR DESCRIPTION
Michael asked about the Web Almond API again, to integrate Brassau with Exhibit.

This patch set allows me to generate an access token that I can give him, without too many hoops, and also tests the API to ensure it actually works.
Turns out, it still does, but at least now we test it so it won't break in the future when TT changes.