### PR TITLE
Add Discourse SSO support

### DIFF
--- a/config.js
+++ b/config.js
@@ -157,6 +157,18 @@ module.exports.ENABLE_PROMETHEUS = false;
 // This value should match the "bearer_token" prometheus configuration value
 module.exports.PROMETHEUS_ACCESS_TOKEN = null;
 
+// Single-Sign-On for discourse
+// See https://meta.discourse.org/t/official-single-sign-on-for-discourse-sso/13045
+// for the protocol
+//
+// SSO will be disabled (404 error) if SSO_SECRET or SSO_REDIRECT is null
+//
+// Unlike OAuth, there is no "confirm" step before user's data is sent to the
+// requesting service, hence this secret REALLY must be secret
+module.exports.DISCOURSE_SSO_SECRET = null;
+// this should be the origin only, /session/sso_login will be appended
+module.exports.DISCOURSE_SSO_REDIRECT = null;
+
 // load more configuration that should not go in git (eg secret keys)
 try {
     Object.assign(module.exports, require('./secret_config.js'));

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "deep-equal": "^1.0.1",
     "dialogflow": "^0.5.0",
     "dialogflow-fulfillment": "^0.5.0",
+    "discourse-sso": "^1.0.3",
     "errorhandler": "~1.4.2",
     "express": "^4.15.2",
     "express-mysql-session": "^2.0.0",

--- a/stanford/config.js
+++ b/stanford/config.js
@@ -47,3 +47,5 @@ module.exports.EXTRA_ABOUT_PAGES = [
         navbar: _("Get Involved")
     }
 ];
+
+module.exports.DISCOURSE_SSO_REDIRECT = 'https://discourse.almond.stanford.edu';

--- a/tests/load_test_webalmond.js
+++ b/tests/load_test_webalmond.js
@@ -31,6 +31,7 @@ async function main() {
             username: 'bob',
             password: '12345678',
             email: 'bob@localhost',
+            email_verified: true,
             locale: 'en-US',
             timezone: 'America/Los_Angeles',
         });

--- a/tests/thingpedia-integration.sh
+++ b/tests/thingpedia-integration.sh
@@ -28,6 +28,7 @@ module.exports.WITH_THINGPEDIA = 'embedded';
 module.exports.THINGPEDIA_URL = '/thingpedia';
 module.exports.ENABLE_PROMETHEUS = true;
 module.exports.PROMETHEUS_ACCESS_TOKEN = 'my-prometheus-access-token';
+module.exports.DISCOURSE_SSO_SECRET = 'd836444a9e4084d5b224a60c208dce14';
 EOF
 
 workdir=`mktemp -t -d webalmond-integration-XXXXXX`

--- a/tests/webalmond-integration.sh
+++ b/tests/webalmond-integration.sh
@@ -19,12 +19,17 @@ export JWT_SIGNING_KEY
 SECRET_KEY="not so secret key"
 export SECRET_KEY
 
+# note: the discourse_sso_secret SHOULD NEVER be in plain text in secret_config.js
+# this is just for ease of testing
+# this secret is the one used by the discourse tutorial, which simplifies testing
 cat > $srcdir/secret_config.js <<'EOF'
 module.exports.SERVER_ORIGIN = 'http://127.0.0.1:7070';
 module.exports.WITH_THINGPEDIA = 'external';
 module.exports.THINGPEDIA_URL = 'https://almond-dev.stanford.edu/thingpedia';
 module.exports.THINGENGINE_MANAGER_ADDRESS = ['./control1', './control2'];
 module.exports.THINGENGINE_MANAGER_AUTHENTICATION = 'foo bar baz';
+module.exports.DISCOURSE_SSO_SECRET = 'd836444a9e4084d5b224a60c208dce14';
+module.exports.DISCOURSE_SSO_REDIRECT = 'https://discourse.almond.stanford.edu';
 EOF
 
 # clean the database and bootstrap

--- a/tests/website/index.js
+++ b/tests/website/index.js
@@ -20,6 +20,7 @@ async function seq(array) {
 seq([
     ('./test_public_endpoints'),
     ('./test_register'),
+    ('./test_sso'),
     ('./test_me'),
     ('./test_my_api'),
     ('./test_admin'),

--- a/tests/website/scaffold.js
+++ b/tests/website/scaffold.js
@@ -115,7 +115,11 @@ function assertRedirect(request, redirect) {
             throw err;
         if (err.code < 300 || err.code >= 400)
             throw err;
-        assert.strictEqual(err.redirect, Url.resolve(Config.SERVER_ORIGIN, redirect));
+
+        if (typeof redirect === 'function')
+            redirect(err.redirect);
+        else
+            assert.strictEqual(err.redirect, Url.resolve(Config.SERVER_ORIGIN, redirect));
     });
 }
 

--- a/tests/website/test_sso.js
+++ b/tests/website/test_sso.js
@@ -1,0 +1,47 @@
+// -*- mode: js; indent-tabs-mode: nil; js-basic-offset: 4 -*-
+//
+// This file is part of Almond Cloud
+//
+// Copyright 2019 The Board of Trustees of the Leland Stanford Junior University
+//
+// Author: Giovanni Campagna <gcampagn@cs.stanford.edu>
+//
+// See COPYING for details
+"use strict";
+
+const assert = require('assert');
+const qs = require('qs');
+const Url = require('url');
+
+const { assertHttpError, assertRedirect, sessionRequest } = require('./scaffold');
+const { login } = require('../login');
+
+async function testSSO() {
+    const session = await login('bob', '12345678');
+
+    // structurally invalid (wrong length, not hex)
+    await assertHttpError(sessionRequest('/user/sso/discourse', 'GET', { sso: 'bm9uY2U9Y2I2ODI1MWVlZmI1MjExZTU4YzAwZmYxMzk1ZjBjMGI\n' , sig: 'invalid' }, session),
+        403, 'Invalid signature');
+
+    // cryptographically invalid (wrong key)
+    await assertHttpError(sessionRequest('/user/sso/discourse', 'GET', { sso: 'bm9uY2U9Y2I2ODI1MWVlZmI1MjExZTU4YzAwZmYxMzk1ZjBjMGI\n' , sig: '2828aa29899722b35a2f191d34ef9b3ce695e0e6eeec47deb46d588d70c7cb56' }, session),
+        403, 'Invalid signature');
+
+    await assertRedirect(sessionRequest('/user/sso/discourse', 'GET', { sso: 'bm9uY2U9Y2I2ODI1MWVlZmI1MjExZTU4YzAwZmYxMzk1ZjBjMGI\n' , sig: '0d7facea785e25b2b30e9dc653df1f3cff3abc564aa5ca397010a49b77bc405a' }, session, { followRedirects: false }), (redirect) => {
+        assert(redirect.startsWith('https://discourse.almond.stanford.edu/session/sso_login'));
+
+        const parsed = Url.parse(redirect, { parseQueryString: true });
+        const decoded = qs.parse(Buffer.from(parsed.query.sso, 'base64').toString());
+        assert.strictEqual(decoded.email, 'bob@localhost');
+        assert.strictEqual(decoded.username, 'bob');
+        assert.strictEqual(decoded.admin, 'false');
+        assert.strictEqual(decoded.nonce, 'cb68251eefb5211e58c00ff1395f0c0b');
+    });
+}
+
+async function main() {
+    await testSSO();
+}
+module.exports = main;
+if (!module.parent)
+    main();

--- a/yarn.lock
+++ b/yarn.lock
@@ -2418,6 +2418,11 @@ dir-glob@^2.0.0:
   dependencies:
     path-type "^3.0.0"
 
+discourse-sso@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/discourse-sso/-/discourse-sso-1.0.3.tgz#b5390353e949b2271a0761834303f89b3f7f24cc"
+  integrity sha1-tTkDU+lJsicaB2GDQwP4mz9/JMw=
+
 doctrine@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-2.1.0.tgz#5cd01fc101621b42c4cd7f5d1a66243716d3f39d"


### PR DESCRIPTION
This enable users of the Almond's discourse community to log in
with their existing Almond credentials.

(Or more correctly, it forces contributors to the discourse to
make an account on Almond, which gives us users)

Fixes #201