### PR TITLE
Wip/readme patch

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ sudo apt install nodejs cvc4 graphicsmagick libcairo2-dev libpango1.0-dev libgif
 ```
 On Fedora:
 ```
-sudo dnf install nodejs cvc4 GraphicsMagick cairo-devel pango-devel giflib-devel libjpeg libcap-devel libsystemd-devel bubblewrap -y
+sudo dnf install nodejs cvc4 GraphicsMagick cairo-devel pango-devel giflib-devel libjpeg-devel libcap-devel systemd-devel bubblewrap -y
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -56,11 +56,6 @@ sudo dnf install mariadb-server //Fedora
 
 This repository uses yarn for dependency tracking.
 You should install yarn from [its website](https://yarnpkg.com/en/docs/install).
-Then place the following `.yarnrc` in your home directory or in the root directory of `almond-cloud`:
-```
-build_from_source true
-```
-
 And then run:
 
 ```


### PR DESCRIPTION
- Fix a couple typos in the dependency list 
- Remove `build_from_source true` because of https://github.com/grpc/grpc-node/issues/739, 