### PR TITLE
Validate tokenization errors in examples before accepting the device

### DIFF
--- a/routes/thingpedia_upload.js
+++ b/routes/thingpedia_upload.js
@@ -100,6 +100,8 @@ async function doCreateOrUpdate(kind, create, req, res) {
                         (req.user.roles & user.Role.THINGPEDIA_ADMIN) === 0)
                         throw new Error(req._("Existing device not found"));
                 }
+
+                await Validation.tokenizeAllExamples('en', dataset.examples);
             } catch(e) {
                 console.error(e.stack);
                 res.render('thingpedia_device_create_or_edit', { page_title:


### PR DESCRIPTION
If we wait to validate the examples until we import them into
the database, we might have to rollback the transaction, which
requires throwing an exception. It's too late to throw an exception
at that point: it will fail with a 500 error rather than the correct
error banner.

Fixes #250 