### PR TITLE
Strip regexp-unsafe tokens from example search keys

### DIFF
--- a/model/example.js
+++ b/model/example.js
@@ -10,7 +10,7 @@
 "use strict";
 
 const db = require('../util/db');
-const { tokenize } = require('../util/tokenize');
+const { tokenize, stripUnsafeTokens } = require('../util/tokenize');
 
 function createMany(client, examples) {
     if (examples.length === 0)
@@ -108,7 +108,7 @@ module.exports = {
     },
 
     getCommandsByFuzzySearchForUser(client, language, userId, query) {
-        const regexp = '(^| )(' + tokenize(query).join('|') + ')( |$)';
+        const regexp = '(^| )(' + stripUnsafeTokens(tokenize(query)).join('|') + ')( |$)';
         return db.selectAll(client, `
             (select eu.id,eu.language,eu.type,eu.utterance,
              eu.preprocessed,eu.target_code,eu.click_count,eu.like_count,eu.is_base,null as kind,u.username as owner_name,
@@ -156,7 +156,7 @@ module.exports = {
     },
 
     getCommandsByFuzzySearch(client, language, query) {
-        const regexp = '(^| )(' + tokenize(query).join('|') + ')( |$)';
+        const regexp = '(^| )(' + stripUnsafeTokens(tokenize(query)).join('|') + ')( |$)';
         return db.selectAll(client, `
             (select eu.id,eu.language,eu.type,eu.utterance,
              eu.preprocessed,eu.target_code,eu.click_count,eu.like_count,eu.is_base,null as kind,u.username as owner_name
@@ -211,7 +211,7 @@ module.exports = {
     },
 
     getByKey(client, key, org, language) {
-        const regexp = '(^| )(' + tokenize(key).join('|') + ')( |$)';
+        const regexp = '(^| )(' + stripUnsafeTokens(tokenize(key)).join('|') + ')( |$)';
         if (org === -1) { // admin
             return db.selectAll(client,
               `(select eu.id,eu.language,eu.type,eu.utterance,eu.preprocessed,

--- a/tests/unit/test_tokenize.js
+++ b/tests/unit/test_tokenize.js
@@ -11,7 +11,7 @@
 
 const assert = require('assert');
 
-const { tokenize, rejoin } = require('../../util/tokenize');
+const { tokenize, rejoin, stripUnsafeTokens } = require('../../util/tokenize');
 
 function testTokenize() {
     assert.deepStrictEqual(tokenize('a b c'), ['a', 'b', 'c']);
@@ -31,9 +31,24 @@ function testRejoin() {
     assert.strictEqual(rejoin(['', 'b', 'c']), ' b c');
 }
 
+function testStripUnsafeTokens() {
+    assert.deepStrictEqual(stripUnsafeTokens(['a', 'b', 'c']), ['a', 'b', 'c']);
+    assert.deepStrictEqual(stripUnsafeTokens(['a', 'b', '?']), ['a', 'b']);
+    assert.deepStrictEqual(stripUnsafeTokens(['a', '?', 'c']), ['a', 'c']);
+    assert.deepStrictEqual(stripUnsafeTokens(['a', '.', 'c']), ['a', 'c']);
+    assert.deepStrictEqual(stripUnsafeTokens(['a', '*', 'c']), ['a', 'c']);
+    assert.deepStrictEqual(stripUnsafeTokens(['a', '+', 'c']), ['a', 'c']);
+    assert.deepStrictEqual(stripUnsafeTokens(['a', '\\', 'c']), ['a', 'c']);
+    assert.deepStrictEqual(stripUnsafeTokens(['a', '\\b', 'c']), ['a', 'c']);
+    assert.deepStrictEqual(stripUnsafeTokens(['a', 'b\\', 'c']), ['a', 'c']);
+    assert.deepStrictEqual(stripUnsafeTokens(['a', '?b', 'c']), ['a', 'c']);
+    assert.deepStrictEqual(stripUnsafeTokens(['a', 'b?', 'c']), ['a', 'c']);
+}
+
 function main() {
     testTokenize();
     testRejoin();
+    testStripUnsafeTokens();
 }
 module.exports = main;
 if (!module.parent)

--- a/util/tokenize.js
+++ b/util/tokenize.js
@@ -29,6 +29,25 @@ function* split(pattern, regexp) {
         yield pattern.substring(i, pattern.length);
 }
 
+function stripUnsafeTokens(tokens) {
+    const cleaned = [];
+
+    for (let tok of tokens) {
+        let safe = true;
+        for (let char of ['?', '*', '.', '(', ')', '+', '\\']) {
+            if (tok.indexOf(char) >= 0) {
+                safe = false;
+                break;
+            }
+        }
+
+        if (safe)
+            cleaned.push(tok);
+    }
+
+    return cleaned;
+}
+
 module.exports = {
     PARAM_REGEX,
 
@@ -51,5 +70,7 @@ module.exports = {
     rejoin(tokens) {
         // FIXME: do something sensible wrt , and .
         return tokens.join(' ');
-    }
+    },
+
+    stripUnsafeTokens,
 };


### PR DESCRIPTION
Example uses a manually constructed regular expression for search, because
the fulltext index is too slow to keep updated.
We need to be very careful in how we construct this regular expression
though, as the regular expression is under user control and we must
remove any unsafe character.

We remove rather than escaping the characters because the processing
happens after tokenization, and dangerous characters have been split
into their own tokens already.

Fixes #249 