### PR TITLE
Import device: approve the existing schema when uploading an auto-approved device

### DIFF
--- a/util/import_device.js
+++ b/util/import_device.js
@@ -63,6 +63,9 @@ async function ensurePrimarySchema(dbClient, name, classDef, req, approve) {
         const existingMeta = (await schemaModel.getMetasByKindAtVersion(dbClient, classDef.kind, existing.developer_version, 'en'))[0];
         if (areMetaIdentical(existingMeta, metas)) {
             console.log('Skipped updating of schema: identical to previous version');
+            if (existing.approved_version === null && approve)
+                await schemaModel.approveByKind(dbClient, classDef.kind);
+
             return [existing.id, false];
         }
 


### PR DESCRIPTION
If the user updates a device and clicks on "Approve automatically"
but also does not modify the schema (e.g. only the code or the dataset
are modified) we would leave the schema unchanged and potentially
not approved.
This could lead to a database inconsistency, where the device is
approved but the schema is not.

Fixes #236